### PR TITLE
Add attributes(a) before examples (#1047)

### DIFF
--- a/Conditions.Rmd
+++ b/Conditions.Rmd
@@ -6,9 +6,11 @@ source("common.R")
 
 ## Introduction
 
-The job of the __condition__ system is to alert the user to problems and give them tools to handle them. In R, conditions encompass errors (`stop()`), warnings (`warning()`), and messages (`message()`), and other custom classes. It's important to understand the condition system because in your own code you'll need to both __signal__ conditions to the user, and to __handle__ conditions thrown by other functions.
+The job of the __condition__ system is to provide a programmable system to alert the user to unusual situations and give them tools to handle them. Base R defines errors (`stop()`), warnings (`warning()`), messages, (`message()`), and interrupts, and packages can extend the system with their own conditions. It's important to understand the condition system because in your own code you'll need to both __signal__ conditions from the functions you create, and to __handle__ conditions signalled by functions you call.
 
-R offers an exceptionally powerful condition handling system based on ideas from Common Lisp, but it's currently not very well documented or often used. This chapter will introduce you to the most important basics, but if you want to learn more, I recommend the following two sources:
+R offers an exceptionally powerful condition handling system based primarily on ideas from Common Lisp. Unfortunately it is rather different to other popular languages, and currently few people take full advantage of the power that it provides. This goal of this chapter is to help you understand the big ideas and provide you with the tools to make best use of them. 
+
+When writing this chapter I found two resources particularly useful. You may also want to read them if you want to learn more about the inspirations and motivations for the system:
 
 * [_A prototype of a condition system for R_][prototype] by Robert Gentleman 
   and Luke Tierney. This describes an early version of R's condition system. 
@@ -27,32 +29,48 @@ R offers an exceptionally powerful condition handling system based on ideas from
 * Discuss the details of signalling conditions
 * Show the basic tools for ignoring conditions
 * Dive into condition handlers, including the details of condition objects.
-* Show a bunch of smaller applications.
+* Introduction custom conditions
+* Show how you can use conditions to solve real problems.
 
 ### Quiz {-}
 
 Want to skip this chapter? Go for it, if you can answer the questions below. Find the answers at the end of the chapter in [answers](#conditions-answers).
 
-1. What are the four most important types of condition?
+1. What are the three most important types of condition?
 
 1. What function do you use to ignore errors in block of code?
+
+1. What's the main difference between `tryCatch()` and `withCallingHandlers()`?
 
 1. Why might you want to create an error with a custom S3 class?
 
 ### Prerequisites
 
+This chapter uses the condition signalling and handling functions from rlang.
+
 ```{r setup}
 library(rlang)
 
 # Waiting for lobstr update
-cst <- function() print(rlang::calltrace(globalenv()))
+cst <- function() print(rlang::trace_back(globalenv()))
 ```
 
 ## Signalling conditions
 \index{errors!throwing}
 \index{conditions!signalling}
 
-There are three conditions that you can signal in code: errors, warnings, and messages. Errors are the most severe; they indicate that there is no way for a function to continue and force execution to terminate. Messages are the mildest; they are way of informing the user that some action has been performed. Warnings fall somewhat in between, and typically indicate that something has gone wrong but the function has been able to recover in some way. There is a final condition that can only be generated interactively: an interrupt, which indicates that the user has "interrupted" execution by pressing Escape, Ctrl + Break, or Ctrl + C (depending on the platform).
+There are three conditions that you can signal in code: errors, warnings, and messages. 
+
+* Errors are the most severe; they indicate that there is no way for a function 
+  to continue and execution must stop. 
+  
+* Messages are the mildest; they are way of informing the user that some action 
+  has been performed. 
+  
+* Warnings fall somewhat in between, and typically indicate that something has 
+  gone wrong but the function has been able to recover in some way. 
+  
+There is a final condition that can only be generated interactively: an interrupt, which indicates that the user has "interrupted" execution by pressing Escape, Ctrl + Break, or Ctrl + C (depending on the platform).
 
 Conditions are usually displayed prominently, in a bold font or coloured red, depending on the R interface. You can tell them apart because errors always start with "Error", warnings with "Warning message", and messages with nothing.
 
@@ -64,9 +82,11 @@ warning("This is what a warning looks like")
 message("This is what a message looks like")
 ```
 
+The next sections go into the details of these functions.
+
 ### Errors
 
-In base R, errors are signalled, or __thrown__, by `stop()`:
+In base R, errors are signalled, or __thrown__, by `stop()` or `rlang::abort()`:
 
 ```{r, error = TRUE}
 f <- function() g()
@@ -83,25 +103,24 @@ h <- function() stop("This is an error!", call. = FALSE)
 f()
 ```
 
-The rlang equivalent, `rlang::abort()`, does not capture the call by default:
+The rlang equivalent to `stop()`, `rlang::abort()`, does this automatically. We'll use `abort()` throughout this chapter, but we won't get to its most compelling feature, the ability to add additional metadata to the condition object, until we're near the end of the chapter.
+
 
 ```{r, error = TRUE}
 h <- function() abort("This is an error!")
 f()
 ```
 
-(Note that will `stop()` will paste together multiple inputs, `abort()` will not. To create complex error messages with abort, I recommend using `glue::glue()`. This allows us to use other arguments to `abort()` for useful features that faciliate custom condition objects.)
+(Note that `stop()` pastes together multiple inputs, while `abort()` does not. To create complex error messages with abort, I recommend using `glue::glue()`. This allows us to use other arguments to `abort()` for useful features that you'll learn about in [custom conditions].)
 
-We'll use of `abort()` throughout this chapter, but we won't get to its most compelling feature, the ability to add additional metadata to the condition object, until we're near the end of the chapter.
-
-The best error messages tell you what is wrong, and point you in the right direction for fixing the problem. Writing good error messages is extremely hard because usually the error occurs because the funtion caller has an incorrect mental model of the function. As a developer it's hard to predict how the mental model might be incorrect, especially when you've just written the function and the details are fresh in your mind. Often writing a good error message takes some iteration - you have to wait until someone sees it in the wild, and then you can talk to them to figure out what went wrong in their prediction of your function's behaviour. There is some evolving advice of writing good error messages in the tidyverse style guide: <http://style.tidyverse.org/error-messages.html>.
+The best error messages tell you what is wrong and point you in the right direction to fix the problem. Writing good error messages is hard because errors typically occur because the user of the function has a flawed mental model. As a developer, it's hard to imagine how the user might be thinking incorrectly about the function, and hence hard to write a message that will steer them in the correct direction. That said, there are some general principles that will help you write good error messages in the tidyverse style guide: <http://style.tidyverse.org/error-messages.html>.
 
 ### Warnings
 
-Warnings are weaker than errors: they signal that something has gone wrong, but the code has been able to recover and continue. They are generated by `warning()`. Unlike errors, you can have multiple warnings from a single function call:
+Warnings, signalled by `warning()` or `rlang::warn()`, are weaker than errors: they signal that something has gone wrong, but the code has been able to recover and continue. Unlike errors, you can have multiple warnings from a single function call:
 
 ```{r}
-f <- function() {
+fw <- function() {
   cat("1\n")
   warning("W1")
   cat("2\n")
@@ -114,7 +133,7 @@ f <- function() {
 By default, warnings are cached and printed only when control returns to the top level:
 
 ```{r, eval = FALSE}
-f()
+fw()
 #> 1
 #> 2
 #> 3
@@ -136,42 +155,81 @@ You can control this behaviour with the `warn` option:
 
 Like `stop()`, `warning()` also has a call argument. It is slightly more useful (since warnings are often more distant from their source), but I still generally suppress it with `call. = FALSE`. The rlang wrapper, `rlang::warn()`, also suppresses by default.
 
-Warnings occupy a somewhat awkward limnal state between messages ("you should know about this") and errors ("you must fix this"). You should be cautious with your use of `warnings()`: warnings are easy to miss if there's a lot of other output, and you don't want your function to recover too easily from clearly incorrect input. In my opinion, base R tends to overuse warnings, and many warnings in base R would be better off as clear errors. For example, take `read.csv()`, which uses the the `file()` function. The file function simple warns if the file exists. That means that when you try and read a file that does not exist, you get both a warning and an error:
+Warnings occupy a somewhat awkward place between messages ("you should know about this") and errors ("you must fix this"). Be cautious with your use of `warnings()`: warnings are easy to miss if there's a lot of other output, and you don't want your function to recover too easily from clearly invalid input. In my opinion, base R tends to overuse warnings, and many warnings in base R would be better off as clear errors. For example, take `read.csv()`, which uses the the `file()` function. The file function simple warns if the file exists. That means that when you try and read a file that does not exist, you get both a warning and an error:
 
 ```{r, error = TRUE}
 read.csv("blah.csv")
 ```
 
-There are a few cases where warnings are clearly useful:
+There are a few cases where warnings are particularly useful:
 
 * When deprecating a function. A deprecated function still works, but you want
-  to ensure users know that they need to transition to a new approach. A 
-  deprecation warning should always help the user do the right thing.
+  to transition users to a new approach.
 
 * When you are reasonably certain you can recover from a problem.
   If you were 100% certain that you could fix the problem, you wouldn't need 
   any message; if you were uncertain that you could correctly fix the issue, 
   you'd throw an error.
 
+Otherwise use with restraint, and carefully think if an error might be more appropriate.
+
 ### Messages
 
-Messages are informational; use them to inform the user of important actions that you function has taken on their behalf. The key principle is don't try and be silently helpful. 
+Messages, signalled by `message()` or `rlang::inform()`, are informational; use them to tell the user that you've done something on their behalf. Good messages are a balancing act: you want to provide just enough information so the user knows what's going on, but not so much that they're overwhelmed.
 
-* Determining a function default that requires a lot of computation.
-  For example, 
+`messages()` are displayed immediately and do not have a `call.` argument:
+
+```{r}
+fm <- function() {
+  cat("1\n")
+  message("M1")
+  cat("2\n")
+  message("M2")
+  cat("3\n")
+  message("M3")
+}
+
+fm()
+```
+
+Good places to use a message are:
+
+* When a default argument requries some non-trivial amount of computation
+  and you want to tell the user what value was used. For example, ggplot2
+  reports the number of bins used if you don't supply a `binwidth`
   
-Generally any function that produces a message should have some way to suppress it, like `quiet = TRUE`. The user can always use `suppressMessages()`, but this the nuclear option as it suppresses all messages regardless of source.
+* When about to start a long running operation. A progress bar (e.g. with 
+  [progress](https://github.com/r-lib/progress)) is even better, but a message 
+  is an easy place start.
+  
+* For functions called primarily for their side-effects that would otherwise
+  be silent. For example, when writing files to disk, calling a web API, or 
+  writing to a database, it's useful provide regular status messages saying
+  what's going on.
 
-Generally, you should use `message()` rather than `cat()` or `print()` for informing the user about actions that your function has taken. This is useful, for example, if you've had to do non-trivial computation to determine the default value of an argument, and you want to let the user know exactly what you've done. Messages are a side-channel. Functions that are primarily called for their printed output (like `print()` or `str()` methods), should use `cat()` to write directly to the console. 
+* When writing a package, you sometimes want to display a message when
+  your package is loaded (i.e. in `.onAttach()`), you must use 
+  `packageStartupMessage()`.
 
-Messages are also important when developing packages: when displaying messages during package startup (i.e. in `.onAttach()`), you must use `packageStartupMessage()`.
+Generally any function that produces a message should have some way to suppress it, like a `quiet = TRUE` argument. It is possible to suppress all messages with `suppressMessages()`, as you'll learn shortly, but it is nice to also give finer grain control.
+
+The purposes of `cat()` and `message()` are complimentary. Use `cat()` when the primary role of the function is to print to the console, like `print()` or `str()` methods. Use `message()` as a side-channel to print to the console when the primary purpose of the function is something else. 
+
+Difference between stdout and stderr?
 
 ### Exercises
+
 
 ## Ignoring conditions 
 \indexc{try()} \indexc{suppressWarnings()} \indexc{suppressMessages()}  
 
-The simplest way of handling conditions in R is to simply ignore them. These are the bluntest instruments, but because they require little knowledge of the condition system, they're a good place to start.
+The simplest way of handling conditions in R is to simply ignore them. There are three functions, one for each of the main condition types:
+
+* `try()` for errors.
+* `suppressWarnings()` for warnings.
+* `suppressMessages()` for messages.
+
+These are the bluntest instruments of condition control, but they're good place to start because they require relatively little knowledge of the condition system.
 
 `try()` allows execution to continue even after an error has occurred. Normally if you run a function that throws an error, it terminates immediately and doesn't return a value: 
 
@@ -204,7 +262,7 @@ default <- NULL
 try(default <- read.csv("possibly-bad-input.csv"), silent = TRUE)
 ```
 
-It is possible, but not recommended, to save the result of `try()` and perform different actions based on whether or not the result has class `try-error`. Instead, it is better to use `tryCatch()`, which we'll get to shortly.
+It is possible, but not recommended, to save the result of `try()` and perform different actions based on whether or not the result has class `try-error`. Instead, it is better to use `tryCatch()` or a higher-level helper; you'll learn about those shortly.
 
 There are two functions that are analagous to `try()` for warnings and messages: `suppressWarnings()` and `suppressMessages()`. These allow you to suppress all warnings and messages generated by a block of code.
 
@@ -850,7 +908,7 @@ record_log <- function(expr, path = stdout()) {
 record_log(log("Hello"))
 ```
 
-You could even imagine layerng that with another function that does some muffling if you want to supress some levels.
+You could even imagine layering with another function that allows you to selectively suppress some logging levels.
 
 ```{r}
 ignore_log_levels <- function(expr, levels) {
@@ -922,7 +980,13 @@ withRestarts(signalCondition(cond), muffle = function() NULL)
 
 ## Quiz answers {#conditions-answers}
 
+1. `error`, `warning`, and `message`.
+
 1. You could use `try()` or `tryCatch()`.
+
+1. `tryCatch()` creates exiting handlers which will terminate the execution
+   of wrapped code; `withCallingHandlers()` creates calling handlers which 
+   don't affect the execution of wrapped code.
 
 1. Because you can then capture specific types of error with `tryCatch()`,
    rather than relying on the comparison of error strings, which is risky,

--- a/Conditions.Rmd
+++ b/Conditions.Rmd
@@ -213,7 +213,7 @@ Good places to use a message are:
 
 Generally any function that produces a message should have some way to suppress it, like a `quiet = TRUE` argument. It is possible to suppress all messages with `suppressMessages()`, as you'll learn shortly, but it is nice to also give finer grain control.
 
-The purposes of `cat()` and `message()` are complimentary. Use `cat()` when the primary role of the function is to print to the console, like `print()` or `str()` methods. Use `message()` as a side-channel to print to the console when the primary purpose of the function is something else. 
+The purposes of `cat()` and `message()` are complimentary. Use `cat()` when the primary role of the function is to print to the console, like `print()` or `str()` methods. Use `message()` as a side-channel to print to the console when the primary purpose of the function is something else.  In other words, `cat()` is for when the user _asks_ for something to be printed and `message()` is for when developer _elects_ to print something.
 
 Difference between stdout and stderr?
 

--- a/Data-structures.Rmd
+++ b/Data-structures.Rmd
@@ -7,7 +7,7 @@ source("common.R")
 
 This chapter summarises the most important data structures in base R: the vector types. You've probably used many (if not all) of them before, but you may not have thought deeply about how they are interrelated. In this brief overview, I won't discuss individual types in depth. Instead, I'll show you how they fit together as a whole. If you need more details, you can find them in R's documentation.
 
-R's vectors can be organised by their dimensionality (1d, 2d, or nd) and whether they're homogeneous (all contents must be of the same type) or heterogeneous (the contents can be of different types). This gives rise to the five data types most often used in data analysis: 
+R's vectors can be organised by their dimension (1d, 2d, or nd) and whether they're homogeneous (all contents must be of the same type) or heterogeneous (the contents can be of different types). This gives rise to the five data types most often used in data analysis: 
 
 |    | Homogeneous   | Heterogeneous |
 |----|---------------|---------------|
@@ -19,7 +19,7 @@ Almost all other objects are built upon these foundations. In [base types], you'
 
 Note that R has no 0-dimensional, or scalar types. Individual numbers or strings, which you might think would be scalars, are actually vectors of length one. 
 
-Given an object, the best way to understand what data structures its composed of is to use `str()`. `str()` is short for structure and it gives a compact, human readable description of any R data structure. \indexc{str()}
+Given an object, the best way to understand what data structures it is composed of is to use `str()`. `str()` is short for structure and it gives a compact, human readable description of any R data structure. \indexc{str()}
 
 ### Quiz {-}
 
@@ -76,7 +76,7 @@ They differ in the types of their elements: all elements of an atomic vector mus
 
 ### Atomic vectors
 
-There are four common types of atomic vectors that I'll discuss in detail: logical, integer, double, and character. Collectively integer and double vectors are known as numeric (. There are two rare types that I will not discuss further: complex and raw. \index{atomic vectors} \index{vectors!atomic|see{atomic vectors}}
+There are four common types of atomic vectors that I'll discuss in detail: logical, integer, double, and character. Collectively integer and double vectors are known as numeric. There are two rare types that I will not discuss further: complex and raw. \index{atomic vectors} \index{vectors!atomic|see{atomic vectors}}
 
 Atomic vectors are usually created with `c()`, short for combine: \indexc{c()}
 
@@ -109,7 +109,7 @@ Missing values are specified with `NA`, which is a logical vector of length 1. `
 
 Given a vector, you can determine its type with `typeof()`. \indexc{typeof()}
 
-Use "is" functions with care. `is.character()`, `is.double()`, `is.integer()`, `is.logical()` are ok. The following are suprising:
+Use "is" functions with care. `is.character()`, `is.double()`, `is.integer()`, `is.logical()` are ok. The following are surprising:
 
 * `is.vector()` tests for vectors with no attributes apart from names
 
@@ -120,7 +120,7 @@ Use "is" functions with care. `is.character()`, `is.double()`, `is.integer()`, `
 
 #### Coercion
 
-All elements of an atomic vector must be the same type, so when you attempt to combine different types they will be __coerced__ to the most flexible type. Types from least to most flexible are: logical, integer, double, and character. \index{coercion}
+All elements of an atomic vector must be the same type, so when you attempt to combine different types they will be __coerced__ to the most flexible one. Types from least to most flexible are: logical, integer, double, and character. \index{coercion}
 
 For example, combining a character and an integer yields a character:
 

--- a/Data-structures.Rmd
+++ b/Data-structures.Rmd
@@ -258,6 +258,7 @@ structure(1:10, my_attribute = "This is a vector")
 By default, most attributes are lost when modifying a vector:
 
 ```{r}
+attributes(a)
 attributes(a[1])
 attributes(sum(a))
 ```

--- a/Data-structures.Rmd
+++ b/Data-structures.Rmd
@@ -297,7 +297,7 @@ To be technically correct, when drawing the named vector `x`, I should draw it l
 knitr::include_graphics("diagrams/data-structures/attr-names-1.png", dpi = 300)
 ```
 
-However, names are so special and so important, that unless I'm trying specifically to draw attention to the attributes data structure, I'll use them the label the vector directly:
+However, names are so special and so important, that unless I'm trying specifically to draw attention to the attributes data structure, I'll use them to label the vector directly:
 
 ```{r, echo = FALSE, out.width = NULL}
 knitr::include_graphics("diagrams/data-structures/attr-names-2.png", dpi = 300)

--- a/Debugging.Rmd
+++ b/Debugging.Rmd
@@ -309,23 +309,26 @@ There are other ways for a function to fail apart from throwing an error or retu
 
     f <- function() g()
     g <- function() message("Hi!")
-    g()
-    # Hi!   
-    message2error(g())
+    f()
+    # Hi!
+    message2error(f())
     # Error in message("Hi!"): Hi!
     traceback()
-    # 10: stop(e) at #2
-    # 9: (function (e) stop(e))(list(message = "Hi!\n", 
-    #      call = message("Hi!")))
-    # 8: signalCondition(cond)
-    # 7: doWithOneRestart(return(expr), restart)
-    # 6: withOneRestart(expr, restarts[[1L]])
-    # 5: withRestarts()
-    # 4: message("Hi!") at #1
-    # 3: g()
-    # 2: withCallingHandlers(code, message = function(e) stop(e)) 
-    #      at #2
-    # 1: message2error(g())
+    # 11: stop(e) at #2
+    # 10: (function (e) 
+    #     stop(e))(list(message = "Hi!\n", call = message("Hi!")))
+    # 9: signalCondition(cond)
+    # 8: doWithOneRestart(return(expr), restart)
+    # 7: withOneRestart(expr, restarts[[1L]])
+    # 6: withRestarts({
+    #        signalCondition(cond)
+    #        defaultHandler(cond)
+    #    }, muffleMessage = function() NULL)
+    # 5: message("Hi!") at #1
+    # 4: g() at #1
+    # 3: f() at #2
+    # 2: withCallingHandlers(code, message = function(e) stop(e)) at #2
+    # 1: message2error(f())
     ```
 
     As with warnings, you'll need to ignore some of the calls on the traceback

--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -439,7 +439,7 @@ Initial versions of rlang used formulas instead of quosures, as an attractive fe
 
 ### When not to use quosures
 
-Almost all quoting functions should capture quosures rather than expressions, and you should default to using `enquo()` and `enquos()` to capture arguments from the user. You should only use expressions if you have a explicitly decided that the environment is not important. This tends to happen in three main cases:
+Almost all quoting functions should capture quosures rather than expressions, and you should default to using `enquo()` and `enquos()` to capture arguments from the user. You should only use expressions if you have explicitly decided that the environment is not important. This tends to happen in three main cases:
 
 *   In code generation, such as you saw in [Slicing an array].
 
@@ -873,7 +873,7 @@ microbenchmark::microbenchmark(
 
 ## Wrapping quoting functions
 
-Now we have all the tools need to wrap a quoting function inside another function, regardless of the whether the quoting function uses tidy evaluation or base R. This is important because it allows you to reduce duplication by turning repeated code into functions. It's straightforward to do this for evaluated argument; now you'll learn the techniques that allow you to wrap quoted arguments.
+Now we have all the tools need to wrap a quoting function inside another function, regardless of whether the quoting function uses tidy evaluation or base R. This is important because it allows you to reduce duplication by turning repeated code into functions. It's straightforward to do this for evaluated arguments; now you'll learn the techniques that allow you to wrap quoted arguments.
 
 ### Tidy evaluation
 
@@ -1056,7 +1056,7 @@ There are two basic way to overcome this challenge:
 
 ### Making formulas
 
-One final aspect to wrapping modelling functions is generating formulas. You just need to learn about one small wrinkle and then you can use the techniques you learned in [Quotation]. Formulas they print the same when evaluated and unevaluated:
+One final aspect to wrapping modelling functions is generating formulas. You just need to learn about one small wrinkle and then you can use the techniques you learned in [Quotation]. Formulas print the same when evaluated and unevaluated:
 
 ```{r}
 y ~ x

--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -10,9 +10,9 @@ The user-facing opposite of quotation is unquotation: it gives the _user_ the ab
 
 This chapter begins with a discussion of evaluation in its purest form with `rlang::eval_bare()` which evaluates an expression in given environment. We'll then see how these ideas are used to implement a handful of base R functions, and then learn about the similar `base::eval()`.
 
-The meat of the chapter focusses on extensions needed to implement evaluation robustly. There are are two big new ideas:
+The meat of the chapter focusses on extensions needed to implement evaluation robustly. There are two big new ideas:
 
-*   We need a new data structure that captures both the expression __and__ then
+*   We need a new data structure that captures both the expression __and__ the
     environment associated with each function argument. We call this data 
     structure a __quosure__.
     
@@ -21,7 +21,7 @@ The meat of the chapter focusses on extensions needed to implement evaluation ro
     and to resolve the ambiguity it creates, introduce the idea of data
     pronouns.
 
-Together, quasiquotation, quosures, data masks, and pronouns form what we call __tidy evaluation__, or tidy eval for short. Tidy eval provides a principled approach to NSE that makes it possible to use such functions both interactively and embedded with other functions. We'll finish off the chapter showing the basic pattern you use to wrap quasiquoting functions, and how you can adapt that pattern base R NSE functions.
+Together, quasiquotation, quosures, data masks, and pronouns form what we call __tidy evaluation__, or tidy eval for short. Tidy eval provides a principled approach to NSE that makes it possible to use such functions both interactively and embedded with other functions. We'll finish off the chapter showing the basic pattern you use to wrap quasiquoting functions, and how you can adapt that pattern to base R NSE functions.
 
 ### Outline {-}
 
@@ -94,7 +94,7 @@ x
 y
 ```
 
-The essence of `local()` is quite simple. We capture the input expression, and create an new environment in which to evaluate it. This inherits from the caller environment so it can access the current lexical scope, but any intermediate variables will be GC'd once the function has returned. 
+The essence of `local()` is quite simple. We capture the input expression, and create a new environment in which to evaluate it. This inherits from the caller environment so it can access the current lexical scope, but any intermediate variables will be GC'd once the function has returned. 
 
 ```{r, error = TRUE}
 local2 <- function(expr) {

--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -1088,7 +1088,7 @@ build_formula(y, a, b, c)
 
 ### Exercises
 
-1.  When model building, typically the predictor and data are relatively 
+1.  When model building, typically the response and data are relatively 
     constant while you rapidly experiment with different predictors. Write a
     small wrapper that allows you to reduce duplication in this situation.
     

--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -414,7 +414,7 @@ Quosures rely on R's internal representation of function arguments as a special 
 There is one big difference between promises and quosures. A promise is evaluated once, when you access it for the first time. Every time you access it subsequently it will return the same value. A quosure must be evaluated explicitly, and each evaluation is independent of the previous evaluations.
 
 ```{r}
-# The argument x is evaluated once, then reuses
+# The argument x is evaluated once, then reused
 foo <- function(x_arg) {
   list(x_arg, x_arg)
 }
@@ -460,7 +460,7 @@ Almost all quoting functions should capture quosures rather than expressions, an
     expr(log(x, base = !!base))
     ```
     
-    (Assuming that `x` will be suppled in some other way)
+    (Assuming that `x` will be supplied in some other way)
 
 ### Exercises
 

--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -117,7 +117,7 @@ Understanding how `base::local()` works is harder, as it uses `eval()` and `subs
 
 ### Application: `source()`
 
-We can create a simple version of `source()` by combining `expr_text()` and `eval_bare()`. We read in the file from disk, use `parse_expr()` to parse the string into a list of expressions, and then use `eval_bare()` to evaluate each component in turn. This version evaluates the code in the caller environment, and invisibly returns the result of the last expression in the file like `source()`. \index{source()}
+We can create a simple version of `source()` by combining `parse_expr()` and `eval_bare()`. We read in the file from disk, use `parse_expr()` to parse the string into a list of expressions, and then use `eval_bare()` to evaluate each component in turn. This version evaluates the code in the caller environment, and invisibly returns the result of the last expression in the file like `source()`. \index{source()}
 
 ```{r}
 source2 <- function(path, env = caller_env()) {

--- a/Evaluation.Rmd
+++ b/Evaluation.Rmd
@@ -641,7 +641,7 @@ threshold_var1 <- function(df, var, val) {
 
 threshold_var2 <- function(df, var, val) {
   var <- as.character(ensym(var))
-  subset2(df, data[[!!var]] >= !!val)
+  subset2(df, .data[[var]] >= !!val)
 }
 ```
 

--- a/Expressions.Rmd
+++ b/Expressions.Rmd
@@ -91,7 +91,7 @@ For more complex code, you can also use RStudio's tree viewer to explore the AST
 
 ### Infix vs. prefix calls
 
-Every call in R can be written in tree form, even if it doesn't look like it at first glance. Take `y <- x * 10` again: what are the functions that are being called? It not as easy to spot as `f(x, 1)` because this expression contains two calls in __infix__ form: `<-` and `*`. Infix functions come **in**between their arguments (so an infix function can only have two arguments), whereas most functions in R are __prefix__ functions where the name of the function comes first [^1]. 
+Every call in R can be written in tree form, even if it doesn't look like it at first glance. Take `y <- x * 10` again: what are the functions that are being called? It is not as easy to spot as `f(x, 1)` because this expression contains two calls in __infix__ form: `<-` and `*`. Infix functions come **in**between their arguments (so an infix function can only have two arguments), whereas most functions in R are __prefix__ functions where the name of the function comes first [^1]. 
 
 [^1]: Some programming languages use __postfix__ calls where the name of the function comes last. If you ever used an old HP calculator, you might have fallen in love with reverse Polish notation, postfix notation for algebra. There is also a family of "stack"-based programming languages descending from Forth which takes this idea as far as it might possibly go.
 

--- a/Functions.Rmd
+++ b/Functions.Rmd
@@ -6,7 +6,7 @@ source("common.R")
 
 ## Introduction
 
-Functions are a fundamental building block of R: to master many of the more advanced techniques in this book, you need a solid foundation in how functions work. You've probably already created many R functions, and you're familiar with the basics of how they work. The focus of this chapter is to turn your existing, informal knowledge of functions into a rigorous understanding of what functions are and how they work. You'll see some interesting tricks and techniques in this chapter, but most of what you'll learn will be more important as the building blocks for more advanced techniques. \index{functions}
+Functions are a fundamental building block of R: to master many of the more advanced techniques in this book, you need a solid foundation in how functions work. You've probably already created many R functions, and you're familiar with the basics of how they work. The focus of this chapter is to turn your existing, informal knowledge of functions into a rigorous understanding of what functions are and how they work. You'll see some interesting tricks and techniques, but most of what you'll learn will be more important as the building blocks for more advanced techniques. \index{functions}
 
 The most important thing to understand about R is that functions are objects in their own right. You can work with them exactly the same way you work with any other type of object. This theme will be explored in depth in [functional programming](#functional-programming).
 
@@ -86,9 +86,9 @@ The only package you'll need is `pryr`, which is used to explore what happens wh
 
 All R functions have three parts: \index{functions!body} \index{functions!formals} \index{functions!environment}
 
-* the `body()`, the code inside the function.
-
 * the `formals()`, the list of arguments which controls how you can call the function.
+
+* the `body()`, the code inside the function.
 
 * the `environment()`, the "map" of the location of the function's variables.
 
@@ -107,7 +107,7 @@ environment(f)
 #> <environment: R_GlobalEnv>
 ```
 
-The assignment forms of `body()`, `formals()`, and `environment()` can also be used to modify functions.
+The assignment forms of `formals()`, `body()`, and `environment()` can also be used to modify functions.
 
 Like all objects in R, functions can also possess any number of additional `attributes()`. One attribute used by base R is "srcref", short for source reference, which points to the source code used to create the function. Unlike `body()`, this contains code comments and other formatting. You can also add attributes to a function. For example, you can set the `class()` and add a custom `print()` method. \index{functions!attributes}
 
@@ -122,7 +122,7 @@ body(sum)
 environment(sum)
 ```
 
-Primitive functions are only found in the `base` package, and since they operate at a low level, they can be more efficient (primitive replacement functions don't have to make copies), and can have different rules for argument matching (e.g., `switch` and `call`).  This, however, comes at a cost of behaving differently from all other functions in R. Hence the R core team generally avoids creating them unless there is no other option.
+Primitive functions are only found in the `base` package and since they operate at a low level, they can be more efficient (primitive replacement functions don't have to make copies) and have different rules for argument matching (e.g. `switch` and `call`).  This, however, comes at the cost of behaving differently from all other functions in R. Hence the R core team generally avoids creating them unless there is no other option.
 
 ### Exercises
 
@@ -151,9 +151,9 @@ Primitive functions are only found in the `base` package, and since they operate
 
 ## Lexical scoping {#lexical-scoping}
 
-Assignment is the act of binding a name to a value. Scoping is the opposite; finding a value given a name.
+Assignment is the act of binding a name to a value. Scoping is the opposite: finding a value given a name.
 
-Scoping is the set of rules that govern how R looks up the value of a symbol. In the example below, scoping is the set of rules that R applies to go from the symbol `x` to its value `10`: \index{scoping!lexical|see{lexical scoping}} \index{lexical scoping}
+Scoping is the set of rules that governs how R looks up the value of a symbol. In the example below, scoping is the set of rules that R applies to go from the symbol `x` to its value `10`: \index{scoping!lexical|see{lexical scoping}} \index{lexical scoping}
 
 ```{r}
 x <- 10

--- a/Introduction.Rmd
+++ b/Introduction.Rmd
@@ -29,7 +29,7 @@ If you are new to R, you might wonder what makes learning such a quirky language
   [twitter](https://twitter.com/search?q=%23rstats),
   [linkedin](http://www.linkedin.com/groups/R-Project-Statistical-Computing-77616),
   and through many local
-  [user groups](http://blog.revolutionanalytics.com/local-r-groups.html).
+  [user groups](https://jumpingrivers.github.io/meetingsR/).
 
 * Powerful tools for communicating your results. R packages make it easy to
   produce html or pdf [reports](http://yihui.name/knitr/), or create

--- a/Meta.Rmd
+++ b/Meta.Rmd
@@ -85,7 +85,7 @@ In the following chapters, you'll learn about the three big ideas that underpin 
 * In __Evaluation__, [Evaluation], you'll learn about the inverse of quotation:
   evaluation. Here you'll learn about an important data structure, the quosure,
   which ensures correct evaluation by capturing both the code to evaluate, and
-  the environment in which to evaluate it. This chapter will show you how put 
+  the environment in which to evaluate it. This chapter will show you how to put 
   all the pieces together to understand how NSE in base R works, and how to
   write your own functions that work like `subset()`.
 

--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -347,7 +347,7 @@ Generally, however, this detail is not important, so elsewhere in the book I'll 
     c <- list(b, a, 1:10)
     ```
 
-1.  What happens when you run this code:
+1.  What happens when you run this code?
 
     ```{r}
     x <- list(1:10)

--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -67,7 +67,7 @@ y <- x
 knitr::include_graphics("diagrams/name-value/binding-2.png", dpi = 300)
 ```
 
-You might have noticed the value `1:3` has a label: `0x74b`. While the vector doesn't have a name, I'll occasionally need to refer to objects independently of their bindings. To make that possible, I'll label values with a unique identifier. These unique identifers have a special form that look like the object's memory "address", i.e. the location in memory in which the object is stored. 
+You might have noticed the value `1:3` has a label: `0x74b`. While the vector doesn't have a name, I'll occasionally need to refer to objects independently of their bindings. To make that possible, I'll label values with a unique identifier. These unique identifers have a special form that looks like the object's memory "address", i.e. the location in memory in which the object is stored. 
 
 You can access the address of an object with `lobstr::obj_addr()`. This allows us to see that `x` and `y` both point to the same location in memory:
 

--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -83,7 +83,7 @@ It takes some time to get your head around the distinction between names and val
 ### Non-syntactic names
 \index{reserved names} \indexc{`} \index{non-syntactic names}
 
-R has strict rules about what constitutes a valid name. A __syntactic__ name must consist of letters[^letters], digits, `.` and `_`, and can't begin with `_`. Additionally, it can not be one of a list of __reserved words__ like `TRUE`, `NULL`, `if`, and `function` (see the complete list in `?Reserved`). Names that don't follow these rules are called __non-syntactic__ names, and if you try to use them, you'll get an error:
+R has strict rules about what constitutes a valid name. A __syntactic__ name must consist of letters[^letters], digits, `.` and `_`, and can't begin with `_` or a digit. Additionally, it can not be one of a list of __reserved words__ like `TRUE`, `NULL`, `if`, and `function` (see the complete list in `?Reserved`). Names that don't follow these rules are called __non-syntactic__ names, and if you try to use them, you'll get an error:
 
 ```{r, eval = FALSE}
 _abc <- 1

--- a/Names-values.Rmd
+++ b/Names-values.Rmd
@@ -330,7 +330,7 @@ Generally, however, this detail is not important, so elsewhere in the book I'll 
 
 1.  Explain why `tracemem()` records two copies when you run this code.
     Hint: carefully look at the difference between this code and the code 
-    show earlier in the section.
+    shown earlier in the section.
      
     ```{r, results = FALSE}
     x <- 1:3

--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -115,7 +115,7 @@ Now that you've seen the basic idea, it's time to talk a little bit about the th
 
 [^quine]: You might be familiar with the name Quine from "quines", computer programs that when run return a copy of their own source code.
 
-Quasiquotation was first used in a programming language, LISP, in the mid-1970s [@bawden-1999]. LISP has one quoting function `` ` ``, and uses `,` for unquoting. Most languages with a LISP heritage behave similarly. For example, racket (`` ` `` and `@`), clojure (`` ` `` and `~`), and julia (`:` and `@`) all have quasiquotation tools that different only slightly from LISP. 
+Quasiquotation was first used in a programming language, LISP, in the mid-1970s [@bawden-1999]. LISP has one quoting function `` ` ``, and uses `,` for unquoting. Most languages with a LISP heritage behave similarly. For example, racket (`` ` `` and `@`), clojure (`` ` `` and `~`), and julia (`:` and `@`) all have quasiquotation tools that differ only slightly from LISP. 
 
 Quasiquotation has only come to R recently (2017). Despite its newness, I teach it in this book because it is a rich and powerful theory that makes many hard problems much easier. Quaisquotation in R is a little different to LISP and descendents. In LISP there is only one function that does quasiquotation (the quote function), and you must call it explicitly when needed. This makes these languages less ambiguous (because there's a clear code signal that something odd is happening), but is less appropriate for R because quasiquotation is such an important part of DSLs for data analysis.
 

--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -914,7 +914,7 @@ tibble::tibble(
   x = 5:1,
 )
 
-# Need to remove comma from z and add column to x
+# Need to remove comma from z and add comma to x
 data.frame(
   y = 1:5,
   z = 3:-1,
@@ -980,9 +980,9 @@ f <- function(...) {
 
 Base functions that use this technique include `interaction()`, `expand.grid()`, `options()`, and `par()`. Since these functions take either a list or `...`, but not both, they are slightly less flexible than functions powered by `list2()`.
 
-Another related technique is used the `RCurl::getURL()` function written by Duncan Temple Lang. `getURL()` take both `...` and `.opts` which are concatenated together.  This is useful when writing functions to call web APIs because you often have some options that need to be passed to every request. You put these in a common list and pass to `.opts`, saving `...` for the options unique for a given call. 
+Another related technique is used in the `RCurl::getURL()` function written by Duncan Temple Lang. `getURL()` take both `...` and `.opts` which are concatenated together.  This is useful when writing functions to call web APIs because you often have some options that need to be passed to every request. You put these in a common list and pass to `.opts`, saving `...` for the options unique for a given call. 
 
-I found this technique particular compelling so you can see it used throughout the tidyverse. Now, however, `rlang::list2()` dots solves more problems, more elegantly, by using the ideas from tidy eval. The tidyverse is slowly migrating to `list2()` style for all functions that take `...`.
+I found this technique particularly compelling so you can see it used throughout the tidyverse. Now, however, `rlang::list2()` dots solves more problems, more elegantly, by using the ideas from tidy eval. The tidyverse is slowly migrating to `list2()` style for all functions that take `...`.
 
 ### Exercises
 

--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -793,7 +793,7 @@ Note that this is often useful if the higher order function have arguments that 
 
 ## Dot-dot-dot (`...`)
 
-Quasiquotation ensures that every quoted argument has an escape hatch that allows the user to unquote, or evaluated, selected components, if needed. A similar and related needs arises with functions that take arbitrary additional arguments with `...`. Take the following two motivating problems:
+Quasiquotation ensures that every quoted argument has an escape hatch that allows the user to unquote, or evaluate, selected components, if needed. A similar and related need arises with functions that take arbitrary additional arguments with `...`. Take the following two motivating problems:
 
 *   What do you do if the elements you want to put in `...` are already stored 
     in a list? For example, imagine you have a list of data frames that 
@@ -819,7 +819,7 @@ Quasiquotation ensures that every quoted argument has an escape hatch that allow
     ```
     
     In this case, you could create a data frame and then change names
-    (ie. `setNames(data.frame(val), var)`), but this feels inelegant.
+    (i.e. `setNames(data.frame(val), var)`), but this feels inelegant.
     How can we do better?
 
 ### `do.call()`

--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -714,7 +714,7 @@ One application is to create functions that work like `graphics::curve()`. `curv
 curve(sin(exp(4 * x)), n = 1000)
 ```
 
-Here `x` is a pronoun. As with `.` in pipelines and `.x` and `.y` in purrr functioanls, `x` doesn't represent a single concrete value, but is instead a placeholder that varies over the range of the plot. Functions, like `curve()`, that use a expression containing a pronoun are known as __anaphoric__ functions[^anaphora].
+Here `x` is a pronoun. As with `.` in pipelines and `.x` and `.y` in purrr functionals, `x` doesn't represent a single concrete value, but is instead a placeholder that varies over the range of the plot. Functions, like `curve()`, that use an expression containing a pronoun are known as __anaphoric__ functions[^anaphora].
 
 [^anaphora]: Anaphoric comes from the linguistics term "anaphora", an expression that is context dependent. Anaphoric functions are found in [Arc](http://www.arcfn.com/doc/anaphoric.html) (a LISP like language), [Perl](http://www.perlmonks.org/index.pl?node_id=666047), and [Clojure](http://amalloy.hubpages.com/hub/Unhygenic-anaphoric-Clojure-macros-for-fun-and-profit).
 

--- a/Quotation.Rmd
+++ b/Quotation.Rmd
@@ -210,7 +210,7 @@ val <- exprs(x = )
 is_missing(val$x)
 ```
 
-There's not much you can do with a list of expressions yet, but we'll see a few techniques later in [case studies](quasi-case-studies): using purrr to work with list of expressions turns out to be a surprisingly powerful tool.
+There's not much you can do with a list of expressions yet, but we'll see a few techniques later in [case studies](quasi-case-studies): using purrr to work with lists of expressions turns out to be a surprisingly powerful tool.
 
 Use `enexpr()` and `enexprs()` inside a function when you want to capture the expressions supplied as arguments _by the user_ of that function. Use `expr()` and `exprs()` when you want to capture expressions that _you_ supply.
 
@@ -311,7 +311,7 @@ Typically you have quoted a function argument for one of two reasons:
 * You want to run, or __evaluate__ the code in a special context,
   as described in depth next chapter.
 
-Evaluation is a rich topic, so we'll cover in depth in the next chapter. Here I'll just illustrate the most important ideas. 
+Evaluation is a rich topic, so we'll cover it in depth in the next chapter. Here I'll just illustrate the most important ideas. 
 
 The most important base R function is `base::eval()`. Its first argument is the expression to evalute:
 
@@ -325,7 +325,7 @@ eval(ru5)
 
 Note that every time we evaluate this expression we get a different result.
 
-The second argument to `eval()` is the environment in which the expression is evaluated. Manipulating this environment gives us amazing power to control the execution of R code. This is the basic technique gives dbplyr the ability to turn R code into SQL.
+The second argument to `eval()` is the environment in which the expression is evaluated. Manipulating this environment gives us amazing power to control the execution of R code. This is the basic technique that gives dbplyr the ability to turn R code into SQL.
 
 ```{r}
 x <- 9
@@ -341,7 +341,7 @@ Evaluation is a developer tool: in combination with quoting, it allows the autho
 
 ### With rlang
 
-All quoting functions in rlang (`expr()`, `enexpr()`, and friends) supporting unquoting with `!!` (called "unquote", and pronounced bang-bang) and `!!!` (called "unquote-splice", and pronounced bang-bang-bang). They both replace nodes in the AST. `!!` is a one-to-one replacement. It takes a single expression and inlines the AST at the location of the `!!`. 
+All quoting functions in rlang (`expr()`, `enexpr()`, and friends) support unquoting with `!!` (called "unquote", and pronounced bang-bang) and `!!!` (called "unquote-splice", and pronounced bang-bang-bang). They both replace nodes in the AST. `!!` is a one-to-one replacement. It takes a single expression and inlines the AST at the location of the `!!`. 
 
 ```{r}
 x <- expr(a + b + c)
@@ -352,7 +352,7 @@ expr(f(!!x, y))
 knitr::include_graphics("diagrams/expressions/bang-bang.png", dpi = 300)
 ```
 
-`!!!` is a one-to-many replacement. It takes a list of expressions and inserts them at them at the location of the `!!!`:
+`!!!` is a one-to-many replacement. It takes a list of expressions and inserts them at the location of the `!!!`:
 
 ```{r}
 x <- exprs(1, 2, 3, y = 10)

--- a/Rcpp.Rmd
+++ b/Rcpp.Rmd
@@ -1087,7 +1087,7 @@ microbenchmark(
 
 <!-- FIXME: needs more context? -->
 
-This example is adapted from ["Rcpp is smoking fast for agent-based models in data frames"](http://www.babelgraph.org/wp/?p=358). The challenge is to predict a model response from three inputs. The basic R version of the predictor looks like:
+This example is adapted from ["Rcpp is smoking fast for agent-based models in data frames"](https://gweissman.github.io/babelgraph/blog/2017/06/15/rcpp-is-smoking-fast-for-agent-based-models-in-data-frames.html). The challenge is to predict a model response from three inputs. The basic R version of the predictor looks like:
 
 ```{r}
 vacc1a <- function(age, female, ily) {

--- a/book/tex/Introduction.tex
+++ b/book/tex/Introduction.tex
@@ -197,7 +197,7 @@ other programming languages, and will help you identify areas where you
 can improve.
 
 To understand why R's object systems work the way they do, I found
-\href{http://mitpress.mit.edu/sicp/full-text/book/book.html}{\emph{The
+\href{https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book.html}{\emph{The
 Structure and Interpretation of Computer Programs}} (SICP) by Harold
 Abelson and Gerald Jay Sussman, particularly helpful. It's a concise but
 deep book. After reading it, I felt for the first time that I could


### PR DESCRIPTION
Made attributes examples clearer since they were returning NULL and NULL, not giving the correct impression of loosing attributes.